### PR TITLE
Private Transaction API Sample

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -238,6 +238,16 @@ type TxPool struct {
 	all     *txLookup                    // All transactions to allow lookups
 	priced  *txPricedList                // All transactions sorted by price
 
+	// BX: attribute for tracking transaction hashes that should remain private.
+	// Some memory management (e.g. cleaning up transactions when they exit the mempool)
+	// would be a good idea, but is not implemented here.
+	//
+	// This is currently only needed for ensuring that transaction hashes don't
+	// get broadcast during syncing transaction state with a new peer, so if your
+	// peer list does not ever change you can remove this attribute and not worry
+	// about managing it.
+	privateTxs          []common.Hash
+
 	chainHeadCh     chan ChainHeadEvent
 	chainHeadSub    event.Subscription
 	reqResetCh      chan *txpoolResetRequest
@@ -275,6 +285,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		reorgDoneCh:     make(chan chan struct{}),
 		reorgShutdownCh: make(chan struct{}),
 		gasPrice:        new(big.Int).SetUint64(config.PriceLimit),
+		privateTxs:		 make([]common.Hash, 0),
 	}
 	pool.locals = newAccountSet(pool.signer)
 	for _, addr := range config.Locals {
@@ -737,7 +748,14 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 // This method is used to add transactions from the RPC API and performs synchronous pool
 // reorganization and event propagation.
 func (pool *TxPool) AddLocals(txs []*types.Transaction) []error {
-	return pool.addTxs(txs, !pool.config.NoLocals, true)
+	return pool.addTxs(txs, !pool.config.NoLocals, true, false)
+}
+
+// BX: Add transactions to mempool without broadcasting them to peers, then marks then
+// to be avoided for future syncs
+func (pool *TxPool) AddPrivateLocal(tx *types.Transaction) error {
+	errs := pool.addTxs([]*types.Transaction{tx}, !pool.config.NoLocals, true, true)
+	return errs[0]
 }
 
 // AddLocal enqueues a single local transaction into the pool if it is valid. This is
@@ -753,12 +771,12 @@ func (pool *TxPool) AddLocal(tx *types.Transaction) error {
 // This method is used to add transactions from the p2p network and does not wait for pool
 // reorganization and internal event propagation.
 func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
-	return pool.addTxs(txs, false, false)
+	return pool.addTxs(txs, false, false, false)
 }
 
 // This is like AddRemotes, but waits for pool reorganization. Tests use this method.
 func (pool *TxPool) AddRemotesSync(txs []*types.Transaction) []error {
-	return pool.addTxs(txs, false, true)
+	return pool.addTxs(txs, false, true, false)
 }
 
 // This is like AddRemotes with a single transaction, but waits for pool reorganization. Tests use this method.
@@ -777,7 +795,7 @@ func (pool *TxPool) AddRemote(tx *types.Transaction) error {
 }
 
 // addTxs attempts to queue a batch of transactions if they are valid.
-func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
+func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync, private bool) []error {
 	// Filter out known ones without obtaining the pool lock or recovering signatures
 	var (
 		errs = make([]error, len(txs))
@@ -819,12 +837,31 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		errs[nilSlot] = err
 		nilSlot++
 	}
+
+	if private {
+		for _, tx := range news {
+			txHash := tx.Hash()
+			dirtyAddrs.privateTxs = append(dirtyAddrs.privateTxs, txHash)
+			pool.privateTxs = append(pool.privateTxs, txHash)
+		}
+	}
+
 	// Reorg the pool internals if needed and return
 	done := pool.requestPromoteExecutables(dirtyAddrs)
 	if sync {
 		<-done
 	}
 	return errs
+}
+
+// BX: query if a transaction is marked as private
+func (pool *TxPool) IsPrivateTxHash(hash common.Hash) bool {
+	for _, privateHash := range pool.privateTxs {
+		if privateHash == hash {
+			return true
+		}
+	}
+	return false
 }
 
 // addTxsLocked attempts to queue a batch of transactions if they are valid.
@@ -1088,7 +1125,11 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	if len(events) > 0 {
 		var txs []*types.Transaction
 		for _, set := range events {
-			txs = append(txs, set.Flatten()...)
+			for _, tx := range set.Flatten() {
+				if dirtyAccounts != nil && !dirtyAccounts.isPrivate(tx) {
+					txs = append(txs, tx)
+				}
+			}
 		}
 		pool.txFeed.Send(NewTxsEvent{txs})
 	}
@@ -1451,6 +1492,12 @@ type accountSet struct {
 	accounts map[common.Address]struct{}
 	signer   types.Signer
 	cache    *[]common.Address
+
+	// BX: add set of transaction hashes to keep private for next broadcast.
+	// This attribute can be removed in favor of TxPool.privateTxs; however,
+	// you can choose to use only this attribute to avoid needing to manage
+	// the list of private hashes, since this struct is short lived.
+	privateTxs []common.Hash
 }
 
 // newAccountSet creates a new address set with an associated signer for sender
@@ -1459,11 +1506,23 @@ func newAccountSet(signer types.Signer, addrs ...common.Address) *accountSet {
 	as := &accountSet{
 		accounts: make(map[common.Address]struct{}),
 		signer:   signer,
+		privateTxs: make([]common.Hash, 0),
 	}
 	for _, addr := range addrs {
 		as.add(addr)
 	}
 	return as
+}
+
+// BX: check is transaction is on the list of private hashes to not broadcast
+func (as *accountSet) isPrivate(tx *types.Transaction) bool {
+	txHash := tx.Hash()
+	for _, privateHash := range as.privateTxs {
+		if privateHash == txHash {
+			return true
+		}
+	}
+	return false
 }
 
 // contains checks if a given address is contained within the set.
@@ -1517,6 +1576,7 @@ func (as *accountSet) merge(other *accountSet) {
 		as.accounts[addr] = struct{}{}
 	}
 	as.cache = nil
+	as.privateTxs = append(as.privateTxs, other.privateTxs...)
 }
 
 // txLookup is used internally by TxPool to track transactions while allowing lookup without

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -751,17 +751,17 @@ func (pool *TxPool) AddLocals(txs []*types.Transaction) []error {
 	return pool.addTxs(txs, !pool.config.NoLocals, true, false)
 }
 
-// BX: Add transactions to mempool without broadcasting them to peers, then marks then
-// to be avoided for future syncs
-func (pool *TxPool) AddPrivateLocal(tx *types.Transaction) error {
-	errs := pool.addTxs([]*types.Transaction{tx}, !pool.config.NoLocals, true, true)
-	return errs[0]
-}
-
 // AddLocal enqueues a single local transaction into the pool if it is valid. This is
 // a convenience wrapper aroundd AddLocals.
 func (pool *TxPool) AddLocal(tx *types.Transaction) error {
 	errs := pool.AddLocals([]*types.Transaction{tx})
+	return errs[0]
+}
+
+// BX: Add transactions to mempool without broadcasting them to peers, then marks then
+// to be avoided for future syncs
+func (pool *TxPool) AddPrivateRemote(tx *types.Transaction) error {
+	errs := pool.addTxs([]*types.Transaction{tx}, false, true, true)
 	return errs[0]
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -223,8 +223,12 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 	return b.eth.BlockChain().SubscribeLogsEvent(ch)
 }
 
-func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-	return b.eth.txPool.AddLocal(signedTx)
+func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error {
+	if private {
+		return b.eth.txPool.AddPrivateLocal(signedTx)
+	} else {
+		return b.eth.txPool.AddLocal(signedTx)
+	}
 }
 
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -225,7 +225,7 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error {
 	if private {
-		return b.eth.txPool.AddPrivateLocal(signedTx)
+		return b.eth.txPool.AddPrivateRemote(signedTx)
 	} else {
 		return b.eth.txPool.AddLocal(signedTx)
 	}

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -121,6 +121,9 @@ type txPool interface {
 	// SubscribeNewTxsEvent should return an event subscription of
 	// NewTxsEvent and send events to the given channel.
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+
+	// BX: check to ensure that private transaction should not be broadcast
+	IsPrivateTxHash(hash common.Hash) bool
 }
 
 // statusData63 is the network packet for the status message for eth/63.

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -55,7 +55,12 @@ func (pm *ProtocolManager) syncTransactions(p *peer) {
 	var txs types.Transactions
 	pending, _ := pm.txpool.Pending()
 	for _, batch := range pending {
-		txs = append(txs, batch...)
+		// BX: check tx hash before appending for syncing
+		for _, tx := range batch {
+			if !pm.txpool.IsPrivateTxHash(tx.Hash()) {
+				txs = append(txs, tx)
+			}
+		}
 	}
 	if len(txs) == 0 {
 		return

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -988,7 +988,7 @@ func (r *Resolver) SendRawTransaction(ctx context.Context, args struct{ Data hex
 	if err := rlp.DecodeBytes(args.Data, tx); err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx)
+	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx, false)
 	return hash, err
 }
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -69,7 +69,7 @@ type Backend interface {
 	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription
 
 	// Transaction pool API
-	SendTx(ctx context.Context, signedTx *types.Transaction) error
+	SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error
 	GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, error)
 	GetPoolTransactions() (types.Transactions, error)
 	GetPoolTransaction(txHash common.Hash) *types.Transaction

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -563,6 +563,12 @@ web3._extend({
 			params: 3,
 			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null, web3._extend.formatters.inputBlockNumberFormatter]
 		}),
+		new web3._extend.Method({
+			name: 'sendPrivateRawTransaction',
+			call: 'eth_sendPrivateRawTransaction',
+			params: 1,
+			inputFormatter: [null]
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -176,7 +176,7 @@ func (b *LesApiBackend) GetEVM(ctx context.Context, msg core.Message, state *sta
 	return vm.NewEVM(context, txContext, state, b.eth.chainConfig, vm.Config{}), state.Error, nil
 }
 
-func (b *LesApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+func (b *LesApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error {
 	return b.eth.txPool.Add(ctx, signedTx)
 }
 


### PR DESCRIPTION
A sample implementation of a private transaction RPC endpoint in go-ethereum. This code is meant to be an example, and  requires some further work to be production ready.

We suggest adding this endpoint to your mining Geth nodes, then creating a public HTTP endpoint that then calls this endpoint on each of the Geth nodes that are going to be accepting private transactions. You should probably have some rate-limiting and authentication on the public endpoint to control the traffic going to your Geth nodes.

A couple of notes about the code included here:

 - Preventing the new `eth_sendPrivateRawTransaction` from immediately broadcasting the transaction after adding it to the mempool can be done in a stateless manner (i.e. without needing to manage a data structure of transactions that Geth should remember to keep private). This code demonstrates that.
 - Preventing private transactions from being synced when a new peer is added probably cannot be done statelessly. We've included some lines to prevent this syncing and keep track of the private transactions, but this is not a production ready implementation, as some memory management is needed to prevent this list from growing forever.
    - `TxPool.removeTx` is probably an appropriate place to do this
    - A purely in-memory implementation will result in the transactions being synced if the Geth node is restarted. You may want to persist some of this info to disk to be read on startup.